### PR TITLE
fix: allow long form workspace declaration

### DIFF
--- a/packages/dependency/src/index.ts
+++ b/packages/dependency/src/index.ts
@@ -16,7 +16,8 @@ export async function readWorkspaceDependenciesAsync<T = unknown>(options?: Part
   includePeerDependencies: boolean
 }>): Promise<Workspace<T & PackageJson>[]> {
   const rootPackageJson: T & PackageJson = JSON.parse((await readFileAsync(path.resolve((options?.targetPath || process.cwd()), 'package.json'))).toString())
-  const workspacesArray = await Promise.all(rootPackageJson.workspaces.map((w) => globAsync(w)))
+  const workspaces = Array.isArray(rootPackageJson.workspaces) ? rootPackageJson.workspaces : rootPackageJson.workspaces.packages;
+  const workspacesArray = await Promise.all(workspaces.map((w) => globAsync(w)))
   const flattenedWorkspaces = new Set<string>()
   workspacesArray.forEach((workspace) => {
     workspace.forEach((w) => {
@@ -82,7 +83,8 @@ export function readWorkspaceDependencies<T = unknown>(options?: Partial<{
   includePeerDependencies: boolean
 }>): Workspace<T & PackageJson>[] {
   const rootPackageJson: PackageJson = JSON.parse((fs.readFileSync(path.resolve((options?.targetPath || process.cwd()), 'package.json'))).toString())
-  const workspacesArray = rootPackageJson.workspaces.map((w) => glob.sync(w))
+  const workspaces = Array.isArray(rootPackageJson.workspaces) ? rootPackageJson.workspaces : rootPackageJson.workspaces.packages;
+  const workspacesArray = workspaces.map((w) => glob.sync(w))
   const flattenedWorkspaces = new Set<string>()
   workspacesArray.forEach((workspace) => {
     workspace.forEach((w) => {
@@ -147,7 +149,7 @@ export interface PackageJson {
   dependencies?: { [name: string]: string }
   devDependencies?: { [name: string]: string }
   peerDependencies?: { [name: string]: string }
-  workspaces: string[]
+  workspaces: string[] | { packages: string[] }
 }
 
 /**


### PR DESCRIPTION
The CLI would fail when workspaces are declared using their longform, as specified in
https://github.com/npm/rfcs/blob/main/implemented/0026-workspaces.md

#### Fixes(if relevant):
Fixes #11

#### Checks

+ [x] Contains Only One Commit(`git reset` then `git commit`)
+ [x] Build Success(`npm run build`)
+ [x] Lint Success(`npm run lint` to check, `npm run fix` to fix)
+ [ ] Add Test(if relevant, `npm run test` to check)
+ [ ] Add Demo(if relevant)
